### PR TITLE
node: fix data race in SetNodeInterface

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uuid_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/odeke-em/go-uuid"
+)
+
+func TestSetNodeInterfaceGoroutineSafety(t *testing.T) {
+	n := 30
+	doneChan := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func(id int) {
+			defer func() { doneChan <- struct{}{} }()
+			uuid.SetNodeInterface(fmt.Sprintf("%d", id))
+		}(i)
+	}
+
+	for i := 0; i < n; i++ {
+		_ = <-doneChan
+	}
+}

--- a/util.go
+++ b/util.go
@@ -10,6 +10,9 @@ import (
 
 // randomBits completely fills slice b with random data.
 func randomBits(b []byte) {
+	nodeMu.Lock()
+	defer nodeMu.Unlock()
+
 	if _, err := io.ReadFull(rander, b); err != nil {
 		panic(err.Error()) // rand should never fail
 	}


### PR DESCRIPTION
Fixes https://github.com/odeke-em/go-uuid/issues/5.

By running:

``` shell
$ go test -v -race
```
- After

``` shell
PASS
ok    github.com/odeke-em/go-uuid 1.020s
```
- Before

``` shell
==================
WARNING: DATA RACE
Write at 0x000000304620 by goroutine 9:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x537
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous read at 0x000000304620 by goroutine 7:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:29
+0x55
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 9 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 7 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Write at 0x000000304620 by goroutine 10:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x537
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous read at 0x000000304620 by goroutine 7:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:29
+0x55
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 10 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 7 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200fe000 by goroutine 11:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200fe000 by goroutine 9:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:35
+0x247
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 11 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 9 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Write at 0x000000304620 by goroutine 8:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x537
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous read at 0x000000304620 by goroutine 7:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:29
+0x55
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 8 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 7 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200f0600 by goroutine 12:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200f0600 by goroutine 10:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:35
+0x247
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 12 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 10 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200fe008 by goroutine 11:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200fe008 by goroutine 9:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:44
+0x5d5
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 11 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 9 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200fe010 by goroutine 11:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200fe010 by goroutine 9:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:36
+0x292
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 11 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 9 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200f0010 by goroutine 13:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200f0010 by goroutine 7:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:36
+0x292
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 13 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 7 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200fe038 by goroutine 11:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200fe038 by goroutine 9:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:37
+0x360
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 11 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 9 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200f0608 by goroutine 12:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200f0608 by goroutine 10:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:44
+0x5d5
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 12 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 10 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200f0038 by goroutine 13:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200f0038 by goroutine 7:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:37
+0x360
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 13 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 7 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4200fe0e0 by goroutine 11:
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:37
+0xb5
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Previous write at 0x00c4200fe0e0 by goroutine 9:
  net.interfaceTable()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface_bsd.go:39
+0x6bc
  net.Interfaces()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/net/interface.go:93
+0x3b
  github.com/odeke-em/go-uuid.SetNodeInterface()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node.go:31
+0x4fa
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety.func1()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:20
+0x11d

Goroutine 11 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9

Goroutine 9 (running) created at:
  github.com/odeke-em/go-uuid_test.TestSetNodeInterfaceGoroutineSafety()
      /Users/emmanuelodeke/go/src/github.com/odeke-em/go-uuid/node_test.go:21
+0x80
  testing.tRunner()
      /Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:610
+0xc9
==================
PASS
Found 12 data race(s)
exit status 66
FAIL  github.com/odeke-em/go-uuid 1.026s
```
